### PR TITLE
Use zypak-wrapper instead of disabling sandbox

### DIFF
--- a/marktext.sh
+++ b/marktext.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-# We need to disable Chromiums sandbox due flatpak#3044. This should be ok
-# because Mark Text don't use the renderer sandbox.
-/app/marktext/marktext --no-sandbox "$@"
-exit $?
+export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
+exec zypak-wrapper /app/marktext/marktext "$@"


### PR DESCRIPTION
Also: export `TMPDIR`  to solve potential multiple instance issue.

Also: using `exec` will close leftover shell process.