### PR TITLE
Move to freedesktop 21.08 runtime

### DIFF
--- a/com.github.marktext.marktext.json
+++ b/com.github.marktext.marktext.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.github.marktext.marktext",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "20.08",
+    "base-version": "21.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "marktext",
     "rename-appdata-file": "marktext.appdata.xml",


### PR DESCRIPTION
This switches to latest runtime containing updated base dependencies.