### PR TITLE
Remove dconf hole

### DIFF
--- a/com.github.marktext.marktext.json
+++ b/com.github.marktext.marktext.json
@@ -23,11 +23,7 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.freedesktop.secrets",
-        "--filesystem=xdg-run/keyring",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--filesystem=xdg-run/keyring"
     ],
     "modules": [
         "shared-modules/libsecret/libsecret.json",

--- a/com.github.marktext.marktext.json
+++ b/com.github.marktext.marktext.json
@@ -15,7 +15,6 @@
         "--socket=wayland",
         "--share=ipc",
         "--share=network",
-        "--filesystem=home",
         "--filesystem=host",
         "--filesystem=/tmp",
         "--device=dri",


### PR DESCRIPTION
See https://github.com/flathub/flathub/issues/1040


This was added in https://github.com/flathub/com.github.marktext.marktext/commit/e953c085a51710ab350f3f9cd922e935994f07fa, keyring has nothing to do with dconf.